### PR TITLE
Initialize new_events variable

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -364,6 +364,7 @@ else
     every=10
     i=0
     events=0
+    new_events=0
     while [ $i -lt $TIMEOUT ]
     do
       SERVICE_STATUS=$($AWS_ECS describe-services --cluster "$CLUSTER" --service "$SERVICE")


### PR DESCRIPTION
Such as following error occured.

```
ecs-deploy: 行 380: new_events: 未割り当ての変数です
```